### PR TITLE
Reduce debug spam

### DIFF
--- a/src/ComponentHPBar.cs
+++ b/src/ComponentHPBar.cs
@@ -119,7 +119,7 @@ public class HPBar : MonoBehaviour {
 			currHP = hm.hp;
 		}
 
-		Logger.LogDebug($@"Enemy {name}: currHP {hm.hp}, maxHP {maxHP}");
+		Logger.LogFine($@"Enemy {name}: currHP {hm.hp}, maxHP {maxHP}");
 		health_bar.fillAmount = hm.hp / maxHP;
 
 		hpbg.fillAmount = currHP / maxHP;


### PR DESCRIPTION
When debug messages are turned on this spams the mod log every frame. Logging type of Fine is better suited to this type of message.